### PR TITLE
Updated Hook - WHMCS version check for $IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stripped down the provisioning module, you only need to specify the plan to provision instead of all plan options
 ### Fixed
 - All domains are made lower case prior to making API calls
+
+## [1.0.9] - 2020-09-29
+### Fixed
+- Fixed missing class introduced by WHMCS 8.0 Upgrade

--- a/modules/servers/apnscp/hooks.php
+++ b/modules/servers/apnscp/hooks.php
@@ -5,7 +5,16 @@ require_once('lib/Helper.php');
 add_hook('ClientAreaPageProductDetails', 1, function ($vars) {
 
     $server = $vars['serverdata'];
-    $ip     = WHMCS\Utility\Environment\CurrentUser::getIP();
+    
+    // WHMCS version check for $ip
+    if (version_compare(WHMCS\Config\Setting::getValue("Version"), '8', '<'))
+    {
+        $ip     = WHMCS\Utility\Environment\CurrentUser::getIP();
+    }
+    else {
+	$user = (new WHMCS\Authentication\CurrentUser())->user();
+	$ip = $user->currentIp();
+    }
 
     $knownJails = [
         'f2b-sshd'         => 'SSH (f2b-sshd)',


### PR DESCRIPTION
Hey man. This has ONLY been tested against WHMCS 8.0. So the version check logic has not been validated yet. 
I can confirm that everything else is working as expected.